### PR TITLE
BUG124

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -19,4 +19,4 @@ services:
     depends_on:
       - db
     env_file:
-      - ./backend/app.env
+      - ./app.env


### PR DESCRIPTION
**Descrição**<br>
Bug ao levantar o container do backend pois ele não encontrava o arquivo de variaveis de ambiente app.env arrumado trocando o caminho até o arquivo de ./backend/app.env para ./app.env.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [x] Feito por conta própria (Se aplicável).
