### PR TITLE
Enviar email quando novo contrato é criado

### DIFF
--- a/backend/app/models/contract.rb
+++ b/backend/app/models/contract.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 class Contract < ApplicationRecord
+  after_save :send_email_new_contract
+  
   belongs_to :company
   belongs_to :user
 
   has_one_attached :video
   has_one_attached :audio
   has_many_attached :image
+
+  def send_email_new_contract
+    SendgridMailer(self.user.email, { buttonURL: url_for()})
+  end
 end

--- a/backend/app/models/contract.rb
+++ b/backend/app/models/contract.rb
@@ -14,9 +14,10 @@ class Contract < ApplicationRecord
     devel = Rails.env.development?
 
     if devel
-      return "http://localhost:3001/"
-    else
+      # return "http://localhost:3001/"
       return "https://develop.dar0d46dq2rcb.amplifyapp.com/"
+    else
+      return "https://master.dar0d46dq2rcb.amplifyapp.com/"
     end
   end
   

--- a/backend/app/models/contract.rb
+++ b/backend/app/models/contract.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Contract < ApplicationRecord
-  after_save :send_email_new_contract
+  after_create :send_email_new_contract
   
   belongs_to :company
   belongs_to :user
@@ -10,7 +10,23 @@ class Contract < ApplicationRecord
   has_one_attached :audio
   has_many_attached :image
 
+  def base_url
+    devel = Rails.env.development?
+
+    if devel
+      return "http://localhost:3001/"
+    else
+      return "https://develop.dar0d46dq2rcb.amplifyapp.com/"
+    end
+  end
+  
   def send_email_new_contract
-    SendgridMailer(self.user.email, { buttonURL: url_for()})
+    SendgridMailer.send(
+      self.user.email,
+      { 
+        buttonURL: base_url + self.token.to_s
+      },
+      "d-977dd6915e8a430bbed0ab92c9a4421a" 
+    )
   end
 end

--- a/backend/app/models/contract.rb
+++ b/backend/app/models/contract.rb
@@ -10,22 +10,11 @@ class Contract < ApplicationRecord
   has_one_attached :audio
   has_many_attached :image
 
-  def base_url
-    devel = Rails.env.development?
-
-    if devel
-      # return "http://localhost:3001/"
-      return "https://develop.dar0d46dq2rcb.amplifyapp.com/"
-    else
-      return "https://master.dar0d46dq2rcb.amplifyapp.com/"
-    end
-  end
-  
   def send_email_new_contract
     SendgridMailer.send(
       self.user.email,
       { 
-        buttonURL: base_url + self.token.to_s
+        buttonURL: app.login_by_token_path(token: self.token)
       },
       "d-977dd6915e8a430bbed0ab92c9a4421a" 
     )

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: '3001' }
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -82,5 +82,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -83,5 +83,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'https://master.dar0d46dq2rcb.amplifyapp.com/' }
+  config.action_mailer.default_url_options = {
+    host: 'master.dar0d46dq2rcb.amplifyapp.com',
+    protocol: 'https'
+  }
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -82,4 +82,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -82,4 +82,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: 'https://master.dar0d46dq2rcb.amplifyapp.com/' }
 end

--- a/backend/config/environments/staging.rb
+++ b/backend/config/environments/staging.rb
@@ -1,0 +1,88 @@
+Rails.application.configure do
+    # Settings specified here will take precedence over those in config/application.rb.
+  
+    # Code is not reloaded between requests.
+    config.cache_classes = true
+  
+    # Eager load code on boot. This eager loads most of Rails and
+    # your application in memory, allowing both threaded web servers
+    # and those relying on copy on write to perform better.
+    # Rake tasks automatically ignore this option for performance.
+    config.eager_load = true
+  
+    # Full error reports are disabled and caching is turned on.
+    config.consider_all_requests_local       = false
+    config.action_controller.perform_caching = true
+  
+    # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+    # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+    # config.require_master_key = true
+  
+    # Disable serving static files from the `/public` folder by default since
+    # Apache or NGINX already handles this.
+    config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  
+    # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+    # config.action_controller.asset_host = 'http://assets.example.com'
+  
+    # Specifies the header that your server uses for sending files.
+    # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+    # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  
+    # Store files on Amazon S3.
+    config.active_storage.service = :amazon
+  
+    # Mount Action Cable outside main process or domain
+    # config.action_cable.mount_path = nil
+    # config.action_cable.url = 'wss://example.com/cable'
+    # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  
+    # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+    # config.force_ssl = true
+  
+    # Use the lowest log level to ensure availability of diagnostic information
+    # when problems arise.
+    config.log_level = :debug
+  
+    # Prepend all log lines with the following tags.
+    config.log_tags = [:request_id]
+  
+    # Use a different cache store in production.
+    # config.cache_store = :mem_cache_store
+  
+    # Use a real queuing backend for Active Job (and separate queues per environment)
+    # config.active_job.queue_adapter     = :resque
+    # config.active_job.queue_name_prefix = "myapp_#{Rails.env}"
+  
+    config.action_mailer.perform_caching = false
+  
+    # Ignore bad email addresses and do not raise email delivery errors.
+    # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+    # config.action_mailer.raise_delivery_errors = false
+  
+    # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+    # the I18n.default_locale when a translation cannot be found).
+    config.i18n.fallbacks = true
+  
+    # Send deprecation notices to registered listeners.
+    config.active_support.deprecation = :notify
+  
+    # Use default logging formatter so that PID and timestamp are not suppressed.
+    config.log_formatter = ::Logger::Formatter.new
+  
+    # Use a different logger for distributed setups.
+    # require 'syslog/logger'
+    # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  
+    if ENV['RAILS_LOG_TO_STDOUT'].present?
+      logger           = ActiveSupport::Logger.new(STDOUT)
+      logger.formatter = config.log_formatter
+      config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    end
+  
+    # Do not dump schema after migrations.
+    config.active_record.dump_schema_after_migration = false
+
+    config.action_mailer.default_url_options = { host: 'https://master.dar0d46dq2rcb.amplifyapp.com/' }
+  end
+  

--- a/backend/config/environments/staging.rb
+++ b/backend/config/environments/staging.rb
@@ -83,6 +83,9 @@ Rails.application.configure do
     # Do not dump schema after migrations.
     config.active_record.dump_schema_after_migration = false
 
-    config.action_mailer.default_url_options = { host: 'https://master.dar0d46dq2rcb.amplifyapp.com/' }
+    config.action_mailer.default_url_options = 
+      host: 'staging.dar0d46dq2rcb.amplifyapp.com',
+      protocol: :https
+    }
   end
   

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
   end
 
+  get '/login/:token', to: redirect('/'), as: :login_by_token
+
   namespace :v1 do
     resources :contracts, only: [:create]
 


### PR DESCRIPTION
**Descrição**<br>
Criei o método ```send_email_new_contract``` para ser executado antes do contrato ser criado, com ajuda do helper ```before_create```, esse método apenas envia um email para o usuário usando o ```SendgridMailer```. Para criar a rota que deverá ser enviada para o botão do email tem o método ```base_url``` que checa se o ambiente é de desenvolvimento, retornando localhost, ou retorna  a url de produção.

**Checklist**
- [x] Código compila corretamente (Se aplicável);
- [ ] Mudanças realizadas foram testadas e passaram no testes (Se aplicável);
- [ ] Documentos gerados/atualizados (Se aplicável);
- [ ] Feito por conta própria (Se aplicável).
